### PR TITLE
Fix bitmap text, options UI, level order; add font debug script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *~
 *.bak
 dist
+debug
 .venv
 .DS_Store

--- a/magicor/__init__.py
+++ b/magicor/__init__.py
@@ -42,7 +42,9 @@ def set_group(key, val):
     g_groups[key]=val
 
 class Text(object):
-    TEXT_INDEX = "abcdefghijklmnopqrstuvwxyz0123456789.,!?"
+    # Bitmap strip in info.png has physical columns for w,x,y,z in order ... w,y,x,z
+    # (not ... w,x,y,z). Match that so "y" and "x" map to the correct glyph cells.
+    TEXT_INDEX = "abcdefghijklmnopqrstuvwyxz0123456789.,!?"
 
     def __init__(self, surface, font, maxWidth = None):
         self.setSurface(surface, maxWidth)
@@ -57,31 +59,51 @@ class Text(object):
 
     def setFont(self, font):
         self.font = font
-        self.width = self.font.get_width() / len(self.TEXT_INDEX)
+        n = len(self.TEXT_INDEX)
+        fw = int(self.font.get_width())
+        # Pixel-accurate glyph slicing: when the sheet divides evenly (bundled fonts),
+        # use fixed cell geometry only — rounding fw/n avoids x/y mis-selection.
+        if fw % n == 0:
+            self._cell = fw // n
+            self._advance = float(self._cell)
+        else:
+            self._cell = None
+            self._advance = fw / float(n)
+        self.width = self._advance
         self.height = self.font.get_height()
 
     def getWidth(self, s):
-        width = self.font.get_width() / len(self.TEXT_INDEX)
-        return width * len(s)
+        return self._advance * len(s)
+
+    def _glyph_rect(self, index):
+        n = len(self.TEXT_INDEX)
+        if self._cell is not None:
+            c = self._cell
+            return pygame.Rect(index * c, 0, c, self.height)
+        fw = int(self.font.get_width())
+        left = int(round(index * fw / n))
+        right = int(round((index + 1) * fw / n))
+        w = max(1, right - left)
+        return pygame.Rect(left, 0, w, self.height)
 
     def draw(self, s, x, y, wrap = True):
         s = s.lower()
-        srcr = pygame.Rect((0, 0,
-                            self.width,
-                            self.height))
         if wrap:
-            ss = textwrap.wrap(s, self.maxWidth / self.width)
+            cols = max(1, int(self.maxWidth / self._advance))
+            ss = textwrap.wrap(s, cols)
         else:
             ss = [s]
         yy = y
         for l in ss:
-            xx = x
+            xx = float(x)
             for c in l:
                 i = self.TEXT_INDEX.find(c)
                 if i >= 0:
-                    srcr.left = i * self.width
-                    self.surface.blit(self.font, (xx, yy), srcr)
-                xx += self.width
+                    self.surface.blit(
+                        self.font,
+                        (int(round(xx)), int(round(yy))),
+                        self._glyph_rect(i))
+                xx += self._advance
                 if xx - x >= self.maxWidth:
                     break
             yy += self.height

--- a/magicor/sprites/__init__.py
+++ b/magicor/sprites/__init__.py
@@ -133,10 +133,15 @@ class AnimationGroup(pygame.sprite.Group):
         for sprite in self.sprites():
             sprite.draw(surface)
 
-    def sort(self, f = None):
-        if not f:
-            f = self.sortFunc
-        self.sprites().sort(key=lambda b: b.y)
+    def sort(self, f=None, **kwargs):
+        """Order sprites for drawing. *f* is ignored (legacy Py2 cmp callback)."""
+        key = kwargs.pop("key", None)
+        if kwargs:
+            raise TypeError("sort() got an unexpected keyword argument %r"
+                            % next(iter(kwargs)))
+        if key is None:
+            key = lambda b: getattr(b, "y", 0)
+        self.sprites().sort(key=key)
 
     def add(self, *sprites):
         pygame.sprite.Group.add(self, *sprites)

--- a/magicor/states/__init__.py
+++ b/magicor/states/__init__.py
@@ -101,7 +101,7 @@ class MenuState(BaseState):
             else:
                 self.text.font = self.inactiveFont
             self.text.draw(selector[0].lower(),
-                           middle - self.text.getWidth(selector[0]) / 2,
+                           middle - self.text.getWidth(selector[0].lower()) / 2,
                            y + i * self.text.font.get_height(),
                            False)
             i += 1

--- a/magicor/states/options.py
+++ b/magicor/states/options.py
@@ -92,7 +92,7 @@ class OptionsState(BaseState):
         self.options.append((option, callback))
 
     def drawOption(self, y, option):
-        self.text.draw(option.title, 0, y)
+        self.text.draw(option.title, 0, y, False)
         if hasattr(option, "value"):
             if isinstance(option, BoolOption):
                 value = option.value and "true" or "false"
@@ -103,7 +103,8 @@ class OptionsState(BaseState):
             self.text.draw(value,
                            self.screen.get_width()
                            - self.text.getWidth("%s"%value),
-                           y)
+                           y,
+                           False)
 
     def run(self):
         self.control()
@@ -112,7 +113,8 @@ class OptionsState(BaseState):
         for option in (o[0] for o in self.options):
             y = line * self.text.font.get_height()
             if line == self.selected:
-                self.screen.fill(0xff,
+                # Was 0xff (integer 255) which maps to pure blue on 32-bit surfaces.
+                self.screen.fill((200, 200, 220),
                                  (0, y,
                                   self.screen.get_width(),
                                   self.text.font.get_height()))

--- a/magicor/states/title.py
+++ b/magicor/states/title.py
@@ -52,7 +52,7 @@ class TitleState(MenuState):
         for i in range(10):
             self.lights.add(WalkingPenguin(x, 450, 550, self.ice))
             x -= random.randint(32, 128)
-        self.lights.sort(lambda a, b: cmp(a.y, b.y))
+        self.lights.sort()
         if self.logo:
             self.distRect = pygame.Rect((0, 0, 1, self.logo.get_height()))
         if startMusic:
@@ -151,14 +151,13 @@ class LevelSelectState(BaseState):
                     level.theme = theme or None
                     self.levels.append(level)
                     self.levelPaths[level] = path + filename
-        #self.levels.sort(lambda x, y:
-        #                 cmp(x.theme, y.theme)
-        #                 or cmp(x.title, y.title))
-	#start possibly at a level never tried
+        self.levels.sort(key=lambda x: ((x.theme or ""), (x.title or "")))
+        # Start at a level never tried, else resume from save data.
         for i in range(len(self.levels)):
-            if (not self.config.getInt("time_"+self.levels[i].title)):
+            if not self.config.getInt("time_"+self.levels[i].title):
                 self.selected = i
                 break
+        else:
             if self.data.lastLevelFinished:
                 for i in range(len(self.levels)):
                     if (self.levels[i].id == self.data.lastLevelFinished
@@ -170,9 +169,9 @@ class LevelSelectState(BaseState):
                     if self.levels[i].id == self.data.lastLevel:
                         self.selected = i
                         break
-            if config.getBool("music"):
-                self.resources.playMusic("music/menu")
-            self.updateInfo()
+        if self.config.getBool("music"):
+            self.resources.playMusic("music/menu")
+        self.updateInfo()
 
     def control(self):
         if self.controls.escape:

--- a/scripts/dump_font_glyphs.py
+++ b/scripts/dump_font_glyphs.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Split the bitmap font strip (info.png) into one PNG per glyph for visual
+debugging and for aligning TEXT_INDEX with the actual art order.
+
+Run from the repository root::
+
+  uv run python scripts/dump_font_glyphs.py
+  uv run python scripts/dump_font_glyphs.py -o /tmp/font-glyphs
+
+Output files are named like ``info_23_y.png`` (index + character label from
+magicor.Text.TEXT_INDEX). Open the folder and confirm each glyph matches its
+label; if not, TEXT_INDEX should be adjusted to match the strip.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import pygame
+
+
+_LABEL_SAFE = {
+    ".": "dot",
+    ",": "comma",
+    "!": "bang",
+    "?": "qmark",
+}
+
+
+def _safe_label(ch: str) -> str:
+    return _LABEL_SAFE.get(ch, ch)
+
+
+def _glyph_rect(index: int, cell: int | None, fw: int, n: int, height: int) -> pygame.Rect:
+    if cell is not None:
+        return pygame.Rect(index * cell, 0, cell, height)
+    left = int(round(index * fw / n))
+    right = int(round((index + 1) * fw / n))
+    w = max(1, right - left)
+    return pygame.Rect(left, 0, w, height)
+
+
+def dump_strip(
+    font_path: str,
+    out_dir: str,
+    basename: str,
+    text_index: str,
+) -> None:
+    os.makedirs(out_dir, exist_ok=True)
+    surf = pygame.image.load(font_path)
+    fw = int(surf.get_width())
+    fh = int(surf.get_height())
+    n = len(text_index)
+    cell = fw // n if fw % n == 0 else None
+
+    print("Font: %s" % os.path.abspath(font_path))
+    print("Size: %d x %d, glyphs: %d, cell: %s" % (fw, fh, n, cell if cell else "fractional"))
+    print()
+    print("idx  char  filename")
+    print("---  ----  --------")
+
+    for i, ch in enumerate(text_index):
+        src = _glyph_rect(i, cell, fw, n, fh)
+        tile = surf.subsurface(src).copy()
+        label = _safe_label(ch)
+        fn = "%s_%02d_%s.png" % (basename, i, label)
+        out_path = os.path.join(out_dir, fn)
+        pygame.image.save(tile, out_path)
+        print("%3d  %-4r  %s" % (i, ch, fn))
+
+
+def main() -> int:
+    pygame.init()
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-o",
+        "--output",
+        default=os.path.join(_REPO_ROOT, "debug", "font-glyphs"),
+        help="Output directory (created if missing)",
+    )
+    parser.add_argument(
+        "--data-dir",
+        default=os.path.join(_REPO_ROOT, "data", "fonts"),
+        help="Directory containing info.png (and optional info-inactive.png)",
+    )
+    args = parser.parse_args()
+
+    from magicor import Text
+
+    text_index = Text.TEXT_INDEX
+
+    fonts = [
+        ("info", os.path.join(args.data_dir, "info.png")),
+        ("info-inactive", os.path.join(args.data_dir, "info-inactive.png")),
+    ]
+    for basename, path in fonts:
+        if not os.path.isfile(path):
+            print("Skip (not found): %s" % path, file=sys.stderr)
+            continue
+        print()
+        dump_strip(path, args.output, basename, text_index)
+        print("Wrote under: %s" % os.path.abspath(args.output))
+
+    print()
+    print("Compare each PNG label to the drawn glyph. If labels do not match art,")
+    print("edit magicor.Text.TEXT_INDEX so index order matches the strip left-to-right.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes https://github.com/rhelmer/magicor/issues/5
Fixes https://github.com/rhelmer/magicor/issues/6

- Text: integer glyph cells, correct atlas order for w,y,x,z; safer blit positions
- Menu: center labels using lowercased width
- Options: selection highlight uses RGB tuple; draw menu lines without wrap
- Title: level list sort; LevelSelectState init loop/else; AnimationGroup.sort
- Add scripts/dump_font_glyphs.py and gitignore debug/ output